### PR TITLE
fix: Rename package name in launch

### DIFF
--- a/launch/multisim.launch.py
+++ b/launch/multisim.launch.py
@@ -4,7 +4,7 @@ import launch_ros.actions
 def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
-            node_namespace= "turtlesim1", package='turtlesim', node_executable='turtlesim_node', output='screen'),
+            node_namespace= "turtlesim1", package='omni_turtlesim', node_executable='turtlesim_node', output='screen'),
         launch_ros.actions.Node(
-            node_namespace= "turtlesim2", package='turtlesim', node_executable='turtlesim_node', output='screen'),
+            node_namespace= "turtlesim2", package='omni_turtlesim', node_executable='turtlesim_node', output='screen'),
     ])


### PR DESCRIPTION
This PR fixes launch error.

related: 0c59170 (#8)